### PR TITLE
Add option to create release for existing specific tag

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,8 @@ inputs:
     description: "GPG fingerprint to use for signing releases"
   build_script_override:
     description: "Path to custom build script for producing binaries to upload"
+  release_tag_override:
+    description: "Existing tag that the release should be created from"
   go_version:
     description: "The Go version to use for compiling (supports semver spec and ranges)"
     default: "1.18"
@@ -23,5 +25,6 @@ runs:
         GITHUB_REPOSITORY: ${{ github.repository }}
         GITHUB_TOKEN: ${{ github.token }}
         GH_EXT_BUILD_SCRIPT: ${{ inputs.build_script_override }}
+        GH_RELEASE_TAG: ${{ inputs.release_tag_override }}
         GPG_FINGERPRINT: ${{ inputs.gpg_fingerprint }}
       shell: bash

--- a/build_and_release.sh
+++ b/build_and_release.sh
@@ -18,7 +18,10 @@ platforms=(
   windows-arm64
 )
 
-if [[ $GITHUB_REF = refs/tags/* ]]; then
+if [ -n "$GH_RELEASE_TAG" ]; then
+  echo "invoking release tag override $GH_RELEASE_TAG"
+  tag="$GH_RELEASE_TAG"
+elif [[ $GITHUB_REF = refs/tags/* ]]; then
   tag="${GITHUB_REF#refs/tags/}"
 else
   tag="$(git describe --tags --abbrev=0)"


### PR DESCRIPTION
For the purposes of creating a new CLI extension which gets built in one repo, but has its assets uploaded to a release in another repo the associated release tag gets created prior to invoking the release script. Therefore a new optional input parameter (`release_tag_override`) is being added which will be used for the release if provided.