### PR TITLE
Allow overriding `github.token` and creating draft release

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,8 @@ inputs:
     default: "1.18"
   build_script_override:
     description: "Path to custom build script for producing binaries to upload"
+  draft_release:
+    description: "Create a draft release"
   release_tag_override:
     description: "Existing tag that the release should be created from"
 branding:
@@ -38,7 +40,8 @@ runs:
       env:
         GITHUB_REPOSITORY: ${{ github.repository }}
         GITHUB_TOKEN: ${{ steps.choose_token.outputs.TOKEN }}
+        GPG_FINGERPRINT: ${{ inputs.gpg_fingerprint }}
         GH_EXT_BUILD_SCRIPT: ${{ inputs.build_script_override }}
         GH_RELEASE_TAG: ${{ inputs.release_tag_override }}
-        GPG_FINGERPRINT: ${{ inputs.gpg_fingerprint }}
+        DRAFT_RELEASE: ${{ inputs.draft_release }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -3,13 +3,13 @@ description: "Generate a release for a precompiled gh extension"
 inputs:
   gpg_fingerprint:
     description: "GPG fingerprint to use for signing releases"
+  go_version:
+    description: "The Go version to use for compiling (supports semver spec and ranges)"
+    default: "1.18"
   build_script_override:
     description: "Path to custom build script for producing binaries to upload"
   release_tag_override:
     description: "Existing tag that the release should be created from"
-  go_version:
-    description: "The Go version to use for compiling (supports semver spec and ranges)"
-    default: "1.18"
 branding:
   color: purple
   icon: box
@@ -20,10 +20,24 @@ runs:
     - uses: actions/setup-go@v3
       with:
         go-version: ${{ inputs.go_version }}
+
+    # if GITHUB_TOKEN env var is set, use it
+    - id: choose_token
+      run: |
+        if [ -n "$GITHUB_TOKEN" ]; then
+          token=$GITHUB_TOKEN
+        else
+          token=$REPO_TOKEN
+        fi
+        echo "TOKEN=$token" >> "$GITHUB_OUTPUT"
+      env:
+        REPO_TOKEN: ${{ github.token }}
+      shell: bash
+
     - run: ${GITHUB_ACTION_PATH//\\//}/build_and_release.sh
       env:
         GITHUB_REPOSITORY: ${{ github.repository }}
-        GITHUB_TOKEN: ${{ github.token }}
+        GITHUB_TOKEN: ${{ steps.choose_token.outputs.TOKEN }}
         GH_EXT_BUILD_SCRIPT: ${{ inputs.build_script_override }}
         GH_RELEASE_TAG: ${{ inputs.release_tag_override }}
         GPG_FINGERPRINT: ${{ inputs.gpg_fingerprint }}

--- a/build_and_release.sh
+++ b/build_and_release.sh
@@ -32,6 +32,11 @@ if [[ $tag = *-* ]]; then
   prerelease="--prerelease"
 fi
 
+draft_release=""
+if [[ "$DRAFT_RELEASE" = "true" ]]; then
+  draft_release="--draft"
+fi
+
 if [ -n "$GH_EXT_BUILD_SCRIPT" ]; then
   echo "invoking build script override $GH_EXT_BUILD_SCRIPT"
   ./"$GH_EXT_BUILD_SCRIPT" "$tag"
@@ -76,5 +81,5 @@ if gh release view "$tag" >/dev/null; then
   gh release upload "$tag" --clobber -- "${assets[@]}"
 else
   echo "creating release and uploading assets..."
-  gh release create "$tag" $prerelease --title="${GITHUB_REPOSITORY#*/} ${tag#v}" --generate-notes -- "${assets[@]}"
+  gh release create "$tag" $prerelease $draft_release --title="${GITHUB_REPOSITORY#*/} ${tag#v}" --generate-notes -- "${assets[@]}"
 fi


### PR DESCRIPTION
Uses the `GITHUB_TOKEN` env variable if set to allow using a token with more permissions than the `github.token`.

Also adds the option to create a draft release with the `DRAFT_RELEASE` input variable.